### PR TITLE
Make all steps equal

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -83,7 +83,6 @@ export const steps = [
     step: "5",
     name: "Platform Mesh",
     url: "/platform-mesh",
-    main: true,
     technologies: [],
   },
   {


### PR DESCRIPTION
I wondered why there's one step highlighted with a red circle. I don't think this is helpful information, so rather remove this "main" highlight