### PR TITLE
fix: adjust links to moved OpenMFP site

### DIFF
--- a/apeiro-projects.json
+++ b/apeiro-projects.json
@@ -43,7 +43,7 @@
     },
     "openmfp": {
         "name": "OpenMFP",
-        "url": "https://openmfp.org",
+        "url": "https://openmfp.github.io/openmfp.org",
         "description": "The Open Micro Front End Platform (OpenMFP) brings together micro front ends and APIs into a cohesive platform, allowing teams to contribute components while maintaining their independence.",
         "icon": "/img/projects/openmfp.png"
     }

--- a/docs/best-practices/micro-frontends/index.md
+++ b/docs/best-practices/micro-frontends/index.md
@@ -78,7 +78,7 @@ mindmap
       Compatibility, Localization and Accessibility
 ```
 
-[^openmfp]: [OpenMFP](http://openmfp.org/docs)
+[^openmfp]: [OpenMFP](https://openmfp.github.io/openmfp.org/docs)
 [^thoughtworks]: [Thoughtworks technology radar on Micro Frontends](https://www.thoughtworks.com/radar/techniques/micro-frontends)
 [^mforg]: [Micro-Frontends.org](https://micro-frontends.org)
 [^turing]: [What are Micro Frontends and When Should You Use Them?](https://www.turing.com/blog/micro-frontends-what-are-they-when-to-use-them)


### PR DESCRIPTION
Fix the links of OpenMFP as https://openmfp.org was moved to https://openmfp.github.io/openmfp.org.